### PR TITLE
ENH: add a scipy_prep fab command

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -53,6 +53,14 @@ def gitrepos():
             run("git checkout -t origin/maintenance/1.10.x")
             run("git submodule update")
 
+def prepare_scipy():
+    run("mkdir -p repos")
+    with cd("repos"):
+        run("git clone https://github.com/scipy/scipy")
+        with cd("scipy"):
+            run("git submodule init")
+            run("git submodule update")
+
 def setup_wine():
     with cd("repos/numpy-vendor"):
         run("./setup-wine.sh")

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,8 +1,10 @@
-from fabric.api import env, local, run, sudo, cd, hide, prefix
+from fabric.api import env, local, run, sudo, cd
 from fabric.context_managers import shell_env, prefix
 from fabric.operations import put, get
-from fabric.contrib.files import append, exists
+
+
 env.use_ssh_config = True
+
 
 def all():
     prepare()
@@ -53,15 +55,18 @@ def gitrepos():
             run("git checkout -t origin/maintenance/1.10.x")
             run("git submodule update")
 
-def prepare_scipy():
+def prepare_scipy(fork='scipy'):
+    """
+    Use a custom repo with: ``$ fab vagrant prepare_scipy:username``.
+    """
     run("mkdir -p repos")
     with cd("repos"):
-        run("git clone https://github.com/scipy/scipy")
+        run("git clone https://github.com/%s/scipy" % fork)
         with cd("scipy"):
             run("git submodule init")
             run("git submodule update")
 
-    sudo("sudo apt-get install libatlas-base-dev")
+    sudo("apt-get -y install libatlas-base-dev")
     install_numpy_for_scipy()
 
 def install_numpy_for_scipy():

--- a/fabfile.py
+++ b/fabfile.py
@@ -61,6 +61,17 @@ def prepare_scipy():
             run("git submodule init")
             run("git submodule update")
 
+    install_numpy_for_scipy()
+
+def install_numpy_for_scipy():
+    install_cmd = "setup.py config --compiler=mingw32 build --compiler=mingw32 install"
+    with cd("repos/numpy"):
+        for pyver, npver in (('27', '1.6.2'), ('33', '1.7.2'), ('34', '1.7.2')):
+            run("git clean -xdf")
+            run("rm -rf doc/sphinxext")  # otherwise cannot checkout old tags
+            run("git checkout v" + npver)
+            run("wine 'C:\Python%s\python' %s" % (pyver, install_cmd))
+
 def setup_wine():
     with cd("repos/numpy-vendor"):
         run("./setup-wine.sh")

--- a/fabfile.py
+++ b/fabfile.py
@@ -61,6 +61,7 @@ def prepare_scipy():
             run("git submodule init")
             run("git submodule update")
 
+    sudo("sudo apt-get install libatlas-base-dev")
     install_numpy_for_scipy()
 
 def install_numpy_for_scipy():


### PR DESCRIPTION
With these changes it should be possible to build scipy binaries for releases.

I had considered cloning numpy-vendor, but it made more sense to me to allow scipy (and other projects) to add a command ``projectname_prep`` such that changes don't have to be sync'ed back and forth all the time.

EDIT: to be more explicit, the command added is ``fab vagrant scipy_prep``.